### PR TITLE
[2022.11.15] 프로젝트 삭제 기능 구현

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,7 +6,7 @@ const logger = require("morgan");
 const cors = require("cors");
 const db = require("./config/db");
 const corsOptions = {
-  origin: ["http://localhost:3000"],
+  origin: "*",
   credentials: true,
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sa-ux-test-server",
-  "version": "0.4.1",
+  "version": "0.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sa-ux-test-server",
-  "version": "0.4.1",
+  "version": "0.5.1",
   "private": true,
   "repository": "https://github.com/comt-mix/sa-ux-test-server.git",
   "author": "Sang-a Lee <comt-mix@gmail.com>",

--- a/routes/controllers/projects.controller.js
+++ b/routes/controllers/projects.controller.js
@@ -5,14 +5,14 @@ exports.createProject = async (req, res, next) => {
   const { projectName, projectUrl, key } = req.body;
 
   try {
-    await Project.create({
+    const newProject = await Project.create({
       creator: JSON.parse(userId),
       projectName,
       projectUrl,
       key,
     });
 
-    res.json({ result: "success" });
+    res.json({ result: "success", newProject });
   } catch (error) {
     next(error);
   }
@@ -28,6 +28,19 @@ exports.getProject = async (req, res, next) => {
     );
 
     res.json({ result: "success", filteredProjects });
+  } catch (error) {
+    next(error);
+  }
+};
+
+exports.deleteProject = async (req, res, next) => {
+  const result = req.params.id;
+  const projectID = JSON.parse(result).id;
+
+  try {
+    await Project.findByIdAndDelete(projectID).lean();
+
+    res.json({ result: "success" });
   } catch (error) {
     next(error);
   }

--- a/routes/projects.js
+++ b/routes/projects.js
@@ -3,8 +3,9 @@ const router = express.Router();
 const {
   createProject,
   getProject,
+  deleteProject,
 } = require("./controllers/projects.controller");
 
-router.route("/:id").post(createProject).get(getProject);
+router.route("/:id").post(createProject).get(getProject).delete(deleteProject);
 
 module.exports = router;


### PR DESCRIPTION
# Topic
- 프로젝트 삭제 기능 구현

# Detail
- 쓰레기통 모양의 이모티콘을 누르면 프로젝트가 삭제 됨.
- 삭제 확인 모달창을 통해 확인을 진행한 이후 삭제가 완료 됨.
- 클라이언트측에서 모달창 확인버튼을 눌렀을 경우 해당 프로젝트 아이디가 서버에 전송됨.
- 서버에서 전송받은 프로젝트 아이디를 삭제.

# Kanban Link
- https://shaded-calculator-f57.notion.site/DELETE-5ba5d077b2ae4d64bf8baf4ceed33a32

# Kanban List
- [x] 선택된 프로젝트 삭제