### PR TITLE
[2022.11.16] 웹 사이트와 연결하기

### DIFF
--- a/constant/error.js
+++ b/constant/error.js
@@ -3,6 +3,7 @@ const ERROR = {
   INVALID_TOKEN: "Invalid Token",
   NOT_FOUND: "Not Found",
   UNAUTHORIZED_USER: "You are not authorized",
+  FAILED_REQUEST: "Failed to retrieve the requested data. Please try again.",
 };
 
 module.exports = ERROR;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sa-ux-test-server",
-  "version": "0.5.1",
+  "version": "0.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "sa-ux-test-server",
-      "version": "0.3.2",
+      "version": "0.6.1",
       "dependencies": {
         "cookie-parser": "~1.4.4",
         "cors": "^2.8.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sa-ux-test-server",
-  "version": "0.5.1",
+  "version": "0.6.1",
   "private": true,
   "repository": "https://github.com/comt-mix/sa-ux-test-server.git",
   "author": "Sang-a Lee <comt-mix@gmail.com>",

--- a/routes/controllers/tests.controller.js
+++ b/routes/controllers/tests.controller.js
@@ -1,3 +1,12 @@
-exports.tests = (req, res, next) => {
-  res.send("tests");
+const createError = require("http-errors");
+const ERROR = require("../../constant/error");
+
+exports.getKey = (req, res, next) => {
+  const key = req.query.key;
+
+  if (!key) {
+    next(createError(ERROR.FAILED_REQUEST));
+  }
+
+  res.json({ message: "success" });
 };

--- a/routes/tests.js
+++ b/routes/tests.js
@@ -1,7 +1,7 @@
 const express = require("express");
 const router = express.Router();
-const { tests } = require("./controllers/tests.controller");
+const { getKey } = require("./controllers/tests.controller");
 
-router.get("/", tests);
+router.get("/", getKey);
 
 module.exports = router;


### PR DESCRIPTION
### DB에 저장되어 있는 프로젝트
<img width="571" alt="db에 저장된 프로젝트" src="https://user-images.githubusercontent.com/89302818/201962997-978a7517-5684-4486-92fb-ecaed55fd3c0.png">

### 서버에 query로 key값이 들어오는 부분
<img width="585" alt="쿼리로 key값이 들어오는 부분" src="https://user-images.githubusercontent.com/89302818/201964325-07699cd0-fc9e-4bb9-865f-a368b91b2d16.png">

### 웹 사이트 head에 스크립트 태그를 적용한 부분
<img width="743" alt="스크린샷 2022-11-15 오후 5 48 32" src="https://user-images.githubusercontent.com/89302818/201963043-c9e12e87-9f57-4dea-8d5d-d9442023764a.png">



# Topic
- 웹 사이트와 연결하기 기능 구현

# Detail
- 프로젝트 생성시 발행된 고유의 key값을 이용한 스크립트 태그를 실제 테스트하고자 하는 사이트 head에 적용.
- 사이트에 있는 key값이 서버로 들어오는지 확인.
- 서버에 query로 key값이 들어오는 것이 확인됨.

# Kanban Link
- https://shaded-calculator-f57.notion.site/GET-69d90b7da64f41e985d00604a24d320a

# Kanban List
- [x] 스크립트 태그가 심어져 있는 웹 사이트로부터 uniqueKey값 받아오기