### PR TITLE
[2022.11.20] 테스트 데이터 가져오기

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sa-ux-test-server",
-  "version": "0.7.3",
+  "version": "0.8.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "sa-ux-test-server",
-      "version": "0.7.3",
+      "version": "0.8.1",
       "dependencies": {
         "cookie-parser": "~1.4.4",
         "cors": "^2.8.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sa-ux-test-server",
-  "version": "0.7.3",
+  "version": "0.8.1",
   "private": true,
   "repository": "https://github.com/comt-mix/sa-ux-test-server.git",
   "author": "Sang-a Lee <comt-mix@gmail.com>",

--- a/routes/controllers/tests.controller.js
+++ b/routes/controllers/tests.controller.js
@@ -116,3 +116,18 @@ exports.mouseTest = async (req, res, next) => {
     next(error);
   }
 };
+
+exports.getTestlist = async (req, res, next) => {
+  const projectID = req.params.id;
+
+  try {
+    const tests = await Test.find({});
+    const testlist = tests.filter((test) =>
+      String(test.projectId === JSON.parse(projectID)),
+    );
+
+    res.json({ result: "success", testlist });
+  } catch (error) {
+    next(error);
+  }
+};

--- a/routes/tests.js
+++ b/routes/tests.js
@@ -11,4 +11,6 @@ router.get("/", connectTest);
 router.post("/:key/basic", basicTest);
 router.post("/:key/mouse", mouseTest);
 
+router.get("/:id/testlist", getTestlist);
+
 module.exports = router;


### PR DESCRIPTION
<img width="668" alt="테스트 데이터 가져오기" src="https://user-images.githubusercontent.com/89302818/202889090-7810efe9-bc08-4c8d-9bc4-b1b52c0a495c.png">

# Topic
- 클라이언트로 테스트 데이터 가져오기

# Detail
- 서버로 부터 클라이언트로 저장된 테스트 데이터 가져오기

# Kanban Link
- https://shaded-calculator-f57.notion.site/GET-567ef1831ada45c9ac407b13c9eba9f6

# Kanban List
- [x] DB에 저장된 데이터들 가져오기